### PR TITLE
[BUG] java,docker 버전 불일치 해결 (#47)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM openjdk:17
+FROM openjdk:21
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENV SPRING_PROFILES_ACTIVE=prod
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	implementation 'io.sentry:sentry-spring-boot-starter-jakarta'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	testImplementation 'com.h2database:h2'
+	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## 📌 PR 개요

> 이 PR에서 어떤 기능을 추가하거나 수정했는지 간략히 설명해주세요.

- main 브랜치 배포 시 https://api.niedu-service.com에서 발생하던 502 Bad Gateway 에러를 해결
- 원인 : 빌드 환경(GitHub Actions)과 실행 환경(Docker) 간의 Java 버전 불일치


## 🔍 변경 사항

- [x] Dockerfile 수정
- [x]. github/workflows/deploy.yml 수정


## 💡 참고 사항

> 리뷰어가 알아야 할 내용이 있다면 적어주세요.

- 로컬(IntelliJ)의 Java 21 버전에 맞춰, GitHub Actions(컴파일)와 Docker(런타임)의 Java 버전을 모두 21로 통일
- EC2 서버에서 docker logs [container_id] 명령어로 UnsupportedClassVersionError (v65.0 vs v61.0) 에러 로그를 확인하여 원인을 파악


## 📸 화면/API 테스트 캡처 (선택)

> Postman, Swagger, 또는 UI 캡처 등을 첨부하면 좋습니다.

---

## 🙏 리뷰어에게 요청

- [x] Dockerfile과 deploy.yml의 Java 버전이 21로 통일되었는지 확인 부탁드립니다

close #47 